### PR TITLE
Added classifier by globalId

### DIFF
--- a/src/fragments/FragmentClassifier/index.ts
+++ b/src/fragments/FragmentClassifier/index.ts
@@ -266,7 +266,7 @@ export class FragmentClassifier
           throw new Error("To group by GlobalId, properties are needed");
         for (const expressID in group.data) {
             if (group.properties === undefined) continue;
-            const globalId = group.properties[expressID].GlobalId.value;
+            const globalId = group.properties[expressID]?.GlobalId?.value;
             if (globalId === undefined) continue;
             this.saveItem(group, "globalIds", globalId, expressID);
         }

--- a/src/fragments/FragmentClassifier/index.ts
+++ b/src/fragments/FragmentClassifier/index.ts
@@ -260,6 +260,18 @@ export class FragmentClassifier
     );
   }
 
+  byGlobalId(group: FragmentsGroup){
+        const properties = group.properties;
+        if (!properties)
+          throw new Error("To group by GlobalId, properties are needed");
+        for (const expressID in group.data) {
+            if (group.properties === undefined) continue;
+            const globalId = group.properties[expressID].GlobalId.value;
+            if (globalId === undefined) continue;
+            this.saveItem(group, "globalIds", globalId, expressID);
+        }
+  }
+
   private saveItem(
     group: FragmentsGroup,
     systemName: string,


### PR DESCRIPTION
### Description

When storing additional entity data in an external database it is common to use globalIds since these are persistent across different versions of the same IFC model. Therefore it is useful to have a classifier that retrieves fragments based on globalId.

### Additional context

Tested locally with two models loaded and it works.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
