### PR TITLE
fix: prevent creating plan object when ui disabled

### DIFF
--- a/src/fragments/FragmentPlans/index.ts
+++ b/src/fragments/FragmentPlans/index.ts
@@ -162,7 +162,9 @@ export class FragmentPlans
     plane.visible = false;
     const plan = { ...config, plane };
     this._plans.push(plan);
-    this.objects.add(config);
+    if (this.components.uiEnabled) {
+      this.objects.add(config);
+    }
   }
 
   /**


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description
Following this comment : https://github.com/IFCjs/components/issues/194#issuecomment-1840380424
In FragmentPlans component function "create" tries to create new Button even if UI Disabled.

<!-- Please insert your description here. Make sure to provide info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [] Ideally, include relevant tests that fail without this PR but pass with it.
