### PR TITLE
feat: add globalStylesEnabled option

### DIFF
--- a/src/core/Components/index.ts
+++ b/src/core/Components/index.ts
@@ -44,6 +44,9 @@ export class Components implements Disposable {
   /** Whether UI components should be created. */
   uiEnabled = true;
 
+  /** Whether global styles should be loaded automatically. */
+  globalStylesEnabled = true;
+
   private _ui?: UIManager;
   private _renderer?: BaseRenderer;
   private _scene?: Component<THREE.Scene>;

--- a/src/ui/UIManager/index.ts
+++ b/src/ui/UIManager/index.ts
@@ -147,28 +147,31 @@ export class UIManager extends Component<Toolbar[]> implements Disposable {
     this.viewerContainer.style.position = "relative";
     this.viewerContainer.classList.add("obc-viewer");
 
-    // Get material icons
-    const materialIconsLink = document.createElement("link");
-    materialIconsLink.rel = "stylesheet";
-    materialIconsLink.href =
-      "https://fonts.googleapis.com/icon?family=Material+Icons";
+    if (this.components.globalStylesEnabled) {
+      // Get material icons
+      const materialIconsLink = document.createElement("link");
+      materialIconsLink.rel = "stylesheet";
+      materialIconsLink.href =
+        "https://fonts.googleapis.com/icon?family=Material+Icons";
 
-    // Get openbim-components styles
-    const fetchResponse = await fetch(
-      "https://raw.githubusercontent.com/IFCjs/components/main/resources/styles.css"
-    );
-    const componentsCSS = await fetchResponse.text();
-    const styleElement = document.createElement("style");
-    styleElement.id = "openbim-components";
-    styleElement.textContent = componentsCSS;
+      // Get openbim-components styles
+      const fetchResponse = await fetch(
+        "https://raw.githubusercontent.com/IFCjs/components/main/resources/styles.css"
+      );
+      const componentsCSS = await fetchResponse.text();
+      const styleElement = document.createElement("style");
+      styleElement.id = "openbim-components";
+      styleElement.textContent = componentsCSS;
 
-    const firstLinkTag = document.head.querySelector("link");
-    if (firstLinkTag) {
-      // Inserting the styles before any link tag makes sure the developer can override the library styles
-      document.head.insertBefore(materialIconsLink, firstLinkTag);
-      document.head.insertBefore(styleElement, firstLinkTag);
-    } else {
-      document.head.append(materialIconsLink, styleElement);
+      const firstLinkTag = document.head.querySelector("link");
+
+      if (firstLinkTag) {
+        // Inserting the styles before any link tag makes sure the developer can override the library styles
+        document.head.insertBefore(materialIconsLink, firstLinkTag);
+        document.head.insertBefore(styleElement, firstLinkTag);
+      } else {
+        document.head.append(materialIconsLink, styleElement);
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

This PR add the `globalStylesEnabled`.

### Additional context

The `globalStylesEnabled` option allows to disable the automatic fetching of the openbim-components styles.
 This useful if you want to provide the styles by your own and modify/revert scrollbar styling.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
