### PR TITLE
fix-ifcPropertiesProcessor-getProperties

### DIFF
--- a/src/ifc/IfcPropertiesProcessor/index.ts
+++ b/src/ifc/IfcPropertiesProcessor/index.ts
@@ -1,5 +1,5 @@
 import * as WEBIFC from "web-ifc";
-import { FragmentsGroup } from "bim-fragment";
+import { FragmentsGroup, IfcProperties } from "bim-fragment";
 import { IfcPropertiesUtils } from "../IfcPropertiesUtils";
 import { Button, FloatingWindow, SimpleUIComponent, TreeView } from "../../ui";
 import { Disposable, Event, UI, UIElement, Component } from "../../base-types";
@@ -158,11 +158,19 @@ export class IfcPropertiesProcessor
 
   async getProperties(model: FragmentsGroup, id: string) {
     if (!model.hasProperties) return null;
+    const modelProperties: IfcProperties | undefined =
+      model.getLocalProperties();
+    if (modelProperties === undefined) {
+      return null;
+    }
     const map = this._indexMap[model.uuid];
     if (!map) return null;
     const indices = map[id];
     const idNumber = parseInt(id, 10);
-    const props = model.getProperties(idNumber);
+    const props = await model.getProperties(idNumber);
+    if (!props) {
+      throw new Error("Properties not found!");
+    }
     const nativeProperties = this.cloneProperty(props);
 
     if (!nativeProperties) {
@@ -173,12 +181,12 @@ export class IfcPropertiesProcessor
 
     if (indices) {
       for (const index of indices) {
-        const props = model.getProperties(index);
+        const props = await model.getProperties(index);
         if (!props) continue;
         const pset = this.cloneProperty(props);
         if (!pset) continue;
-        this.getPsetProperties(pset, model);
-        this.getNestedPsets(pset, model);
+        this.getPsetProperties(pset, modelProperties);
+        this.getNestedPsets(pset, modelProperties);
         properties.push(pset);
       }
     }


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

I notice a regression in ifcPropertiesProcessor getProperties function :
- model.getProperties is not call with "await" whereas the function is asynchronous
- getPsetProperties and getNestedPsets are call with model (FragmentsGroup) as parameter instead of model.getLocalProperties().

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x ] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [ x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
