### PR TITLE
fix: FragmentHider if-guard

### DIFF
--- a/src/fragments/FragmentHider/index.ts
+++ b/src/fragments/FragmentHider/index.ts
@@ -121,8 +121,11 @@ export class FragmentHider extends Component<void> implements Disposable, UI {
     for (const fragID in items) {
       const ids = items[fragID];
       const fragment = fragments.list[fragID];
-      fragment.setVisibility(visible, ids);
-      this.updateCulledVisibility(fragment);
+
+      if (fragment) {
+        fragment.setVisibility(visible, ids);
+        this.updateCulledVisibility(fragment);
+      }
     }
   }
 


### PR DESCRIPTION
### Description

Simply, an if-clause is needed. In some cases, when We deal with the FragmentTree panel, some retrieved uuids could not point to available fragments.

### Additional context

This happens when FragmentIfcStreamer is being used

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
