### PR TITLE
fix: [BIM Tiles] Error when removing streamed model from scene

### DIFF
--- a/src/fragments/FragmentIfcStreamer/src/geometry-culler-renderer.ts
+++ b/src/fragments/FragmentIfcStreamer/src/geometry-culler-renderer.ts
@@ -296,6 +296,7 @@ export class GeometryCullerRenderer extends CullerRenderer {
 
     this._modelIDIndex.delete(modelID);
     this._indexModelID.delete(index);
+    this._foundGeometries.clear();
   }
 
   addFragment(modelID: string, geometryID: number, frag: FRAGS.Fragment) {


### PR DESCRIPTION
### Description

After streaming an IFC model into the scene, if we call remove(modelID) from the FragmentStreamLoader, an error will be thrown by the loader's GeometryCullerRenderer remove(modelID), because while the _geometry property has been cleared, the _foundGeometry property will still have some of the model's geometry. The error is thrown the next time the culler is updated.

### Additional context

This PR is trying to fix [issue:#345]
There is probably a more thorough approach to fix this issue, but for my use case this worked as intended. I just wanted to at least give attention to this issue.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix

### Before submitting the PR, please make sure you do the following:

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).