### PR TITLE
fix(FaceMeasurement): handle world.isDisposing when setting visibility

### DIFF
--- a/packages/front/src/measurement/FaceMeasurement/index.ts
+++ b/packages/front/src/measurement/FaceMeasurement/index.ts
@@ -290,6 +290,9 @@ export class FaceMeasurement
     if (!this.world) {
       throw new Error("The face measurement needs a world to work!");
     }
+    if (this.world.isDisposing) {
+      return;
+    }
     const scene = this.world.scene.three;
     for (const item of this.selection) {
       const label = item.label.three;


### PR DESCRIPTION
### Description

The FaceMeasurement component throws during `components.dispose()`.

This occurs when the components are being disposed and the world is disposed
before the `FaceMeasurement`. `components.dispose()` calls `enabled = false` before disposing
individual components which causes issues because `FaceMeasurement` calls `setVisibility(false)` when
`enabled` is set.

### Additional context
N/A

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
