### PR TITLE
fix(front): Update currentPlan of Plans component so it is not always…

### DIFF
--- a/packages/front/src/fragments/Plans/index.ts
+++ b/packages/front/src/fragments/Plans/index.ts
@@ -179,6 +179,10 @@ export class Plans extends OBC.Component implements OBC.Disposable {
     const sections = this.components.get(Sections);
     await sections.goTo(id, animate);
     await this.applyCachedPlanCamera();
+    const foundPlan = this.list.find((plan) => plan.id === id);
+    if (foundPlan) {
+      this.currentPlan = foundPlan;
+    }
     this.enabled = true;
   }
 
@@ -195,6 +199,7 @@ export class Plans extends OBC.Component implements OBC.Disposable {
     this.cachePlanCamera();
     const sections = this.components.get(Sections);
     await sections.exit(animate);
+    this.currentPlan = null;
     this.enabled = false;
     this.onExited.trigger();
   }


### PR DESCRIPTION
### Description

Since the latest update the `currentPlan` property of the Plans component was not updated anymore and always `null`.

### Additional context

I access `currentPlan`, e.g. to know the label of the currently active plan to display it in the selection UI. That's why it needs to be updated once the user gos to another plan.
---

### What is the purpose of this pull request?

- [x] Bug fix

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
