### PR TITLE
feat(front): Make cluster element customizable

### DIFF
--- a/packages/front/src/core/Marker/index.ts
+++ b/packages/front/src/core/Marker/index.ts
@@ -63,6 +63,7 @@ export interface IGroupedMarkers {
  * Component for Managing Markers along with creating different types of markers. Every marker is a Simple2DMarker. For every marker that needs to be added, you can use the Manager to add the marker and change its look and feel. 📕 [Tutorial](https://docs.thatopen.com/Tutorials/Components/Front/Marker). 📘 [API](https://docs.thatopen.com/api/@thatopen/components-front/classes/Marker).
  */
 export class Marker extends OBC.Component implements OBC.Disposable {
+  
   /**
    * A unique identifier for the component.
    * This UUID is used to register the component within the Components system.
@@ -88,6 +89,24 @@ export class Marker extends OBC.Component implements OBC.Disposable {
    * Default value is true.
    */
   autoCluster = true;
+
+  private static readonly DEFAULT_CLUSTER_STYLES = {
+    backgroundColor: "#FFFFFF",
+    textColor: "#000000",
+    fontSize: "1.2rem",
+    fontWeight: "500",
+    borderRadius: "50%",
+    padding: "5px 11px",
+    textAlign: "center",
+    cursor: "pointer",
+    hoverBackgroundColor: "#BCF124",
+    transition: undefined,
+  };
+
+  // Customizable cluster element styles
+  clusterElementStyles: Partial<typeof Marker.DEFAULT_CLUSTER_STYLES> = {
+    ...Marker.DEFAULT_CLUSTER_STYLES,
+  };
 
   /**
    * A Map containing the markers grouped by world UUID.
@@ -418,25 +437,44 @@ export class Marker extends OBC.Component implements OBC.Disposable {
   private createClusterElement(key: string) {
     const div = document.createElement("div");
     div.textContent = key;
-    div.style.color = "#000000";
-    div.style.background = "#FFFFFF";
-    div.style.fontSize = "1.2rem";
-    div.style.fontWeight = "500";
-    div.style.pointerEvents = "auto";
-    div.style.borderRadius = "50%";
-    div.style.padding = "5px 11px";
-    div.style.textAlign = "center";
-    div.style.cursor = "pointer";
-    // div.style.transition = "all 0.05s";
+
+    const {
+      backgroundColor,
+      textColor,
+      fontSize,
+      fontWeight,
+      borderRadius,
+      padding,
+      textAlign,
+      cursor,
+      hoverBackgroundColor,
+      transition,
+    } = { ...Marker.DEFAULT_CLUSTER_STYLES, ...this.clusterElementStyles };
+
+    Object.assign(div.style, {
+      background: backgroundColor,
+      color: textColor,
+      fontSize,
+      fontWeight,
+      borderRadius,
+      padding,
+      textAlign,
+      cursor,
+      ...(transition && { transition }),
+    });
+
     div.addEventListener("pointerdown", () => {
       this.navigateToCluster(key);
     });
+
     div.addEventListener("pointerover", () => {
-      div.style.background = "#BCF124";
+      div.style.background = hoverBackgroundColor;
     });
+
     div.addEventListener("pointerout", () => {
-      div.style.background = "#FFFFFF";
+      div.style.background = backgroundColor;
     });
+
     return div;
   }
 


### PR DESCRIPTION
Add possibility to edit the styling defaults of the cluster element (the number defining the count of merged markers)
![image](https://github.com/user-attachments/assets/5d8f6f20-c4d6-44b2-bf56-12f77c81b61f)


<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

Currently it is not possible to adjust the styling of the cluster element. This PR adds a property `clusterElementStyles` where you can pass partial styling values to overwrite the default styling.

### Additional context

Usage:
```
markerComponent.clusterElementStyles = {
  transition: "all 0.3s ease-in-out",
  hoverBackgroundColor: "#FF5733",
};
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
