### PR TITLE
fix: add IDSInfo handling in IDSSpecifications class

### DIFF
--- a/packages/core/src/openbim/IDSSpecifications/index.ts
+++ b/packages/core/src/openbim/IDSSpecifications/index.ts
@@ -40,6 +40,8 @@ export class IDSSpecifications extends Component {
     trimValues: true,
   });
 
+  IDSInfo?: IDSInfo;
+
   constructor(components: Components) {
     super(components);
     components.add(IDSSpecifications.uuid, this);
@@ -104,7 +106,11 @@ export class IDSSpecifications extends Component {
   load(data: string) {
     const result: IDSSpecification[] = [];
     const ids = IDSSpecifications.xmlParser.parse(data).ids;
-    const { specifications } = ids;
+    const { specifications, info } = ids;
+    if (info) {
+      const { info } = ids;
+      this.IDSInfo = { ...info };
+    }
     if (specifications && specifications.specification) {
       const specs = Array.isArray(specifications.specification)
         ? specifications.specification


### PR DESCRIPTION
Ref: issue #628

<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

This PR fixes an issue in the IDSSpecifications component where the info metadata from the IDS file was correctly parsed by the XML parser but was never stored in the class.
As a result, important information such as title, version, author, etc., was lost after loading the IDS file.

The fix ensures that the parsed info block is now saved in the IDSSpecifications class (via a new IDSInfo property), making it accessible for later usage and consistent with the IDS schema.

### Additional context

- Verified that the info fields are now available in the instance after loading an IDS file.
- Added handling for optional fields (e.g. description, copyright, milestone).
- This change does not affect existing specifications parsing.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [] Ideally, include relevant tests that fail without this PR but pass with it.