### PR TITLE
fixing clipper onAfterDelete method

### DIFF
--- a/packages/core/src/core/Clipper/index.ts
+++ b/packages/core/src/core/Clipper/index.ts
@@ -202,6 +202,8 @@ export class Clipper
       plane.world.renderer.setPlane(false, plane.three);
       plane.dispose();
       this.updateMaterialsAndPlanes();
+
+      this.onAfterDelete.trigger(plane);
     });
   }
 


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

<!-- Please insert your description here. Make sure to provide info about the "what" this PR is solving -->
After deleting the clipper plane, the onAfterDelete event is not triggered. This PR resolves that issue.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
- Solution done by triggering the event of onAfterDelete within the setEvent method, which depends on removing any plane from the list DataMap.
- Solution has been tested.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
